### PR TITLE
Missing argument in pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ in your computer.
 2. Install the dependencies
 
 ```bash
-$ pip install requirements.txt
+$ pip install -r requirements.txt
 ```
 
 3. Download the portraits


### PR DESCRIPTION
An argument was missing in the "pip install requirements.txt" command line, causing it to fail