### PR TITLE
Fixed escaped newline in download-units tool

### DIFF
--- a/tools/download-units.sh
+++ b/tools/download-units.sh
@@ -4,7 +4,8 @@ wget https://raw.githubusercontent.com/optc-db/optc-db.github.io/master/common/d
 
 cp units.js modifiedUnits.js
 sed -i 's/window.units =/const startUnits =/g' modifiedUnits.js
-echo '\nconst unitsJSON = JSON.stringify(startUnits)' >> modifiedUnits.js
+echo '' >> modifiedUnits.js
+echo 'const unitsJSON = JSON.stringify(startUnits)' >> modifiedUnits.js
 echo 'const fs = require("fs");' >> modifiedUnits.js
 echo 'fs.writeFile("../data/units.json", unitsJSON, () => console.log("Done"))' >> modifiedUnits.js
 node modifiedUnits.js


### PR DESCRIPTION
The download-units was giving me an error, because the variable declaration was being placed inside the last line of the file (a comment) instead of a new line, like so: 
![1617328029_Code](https://user-images.githubusercontent.com/28060941/113371260-38926e80-9366-11eb-9d8e-3f889636ee04.png)

And giving an error because unitsJSON wouldn't exist.